### PR TITLE
fix horizontal page scroll

### DIFF
--- a/less/app.less
+++ b/less/app.less
@@ -31,7 +31,7 @@ header {
     margin: 0;
 
     .container {
-        padding: 0;
+        padding: 0 @grid-gutter-width / 2;
     }
 
     .header-wrapper {


### PR DESCRIPTION
The changes to remove the ad from the header introduced a bug causing the page to horizontally scroll:

![screen shot 2015-07-03 at 6 40 56 pm](https://cloud.githubusercontent.com/assets/419297/8505417/f35b4182-21b2-11e5-88f2-0c729f5e8aea.png)
